### PR TITLE
Update visualize.md

### DIFF
--- a/sources/visualization.md
+++ b/sources/visualization.md
@@ -1,8 +1,8 @@
 ## 모델 시각화
 
-케라스는(`graphviz`를 사용해서) 케라스 모델을 그래프로 그리기 위한 유틸리티 함수를 제공합니다.
+케라스는(`graphviz`를 사용해서) 케라스 모델을 그래프로 그리기 위한 유틸리티 함수를 제공합니다.  
 
-아래 예시는 모델의 그래프를 그려주고 그 결과를 파일로 저장합니다.
+아래 예시는 모델의 그래프를 그려주고 그 결과를 파일로 저장합니다.  
 ```python
 from keras.utils import plot_model
 plot_model(model, to_file='model.png')
@@ -15,8 +15,8 @@ plot_model(model, to_file='model.png')
 - `expand_nested`(기본값은 `False`)는 중첩된 모델을 그래프상에서 클러스터로 확장할 것인지 여부를 설정합니다.
 - `dpi`(기본값은 96)는 이미지 dpi를 설정합니다.
 
-또한 직접 `pydot.Graph`오브젝트를 만들어 사용할 수도 있습니다. 
-아래는 IPython Notebook에 나타낸 예시입니다.
+또한 직접 `pydot.Graph`오브젝트를 만들어 사용할 수도 있습니다.  
+아래는 IPython Notebook에서 나타낸 예시입니다.
 ```python
 from IPython.display import SVG
 from keras.utils import model_to_dot

--- a/sources/visualization.md
+++ b/sources/visualization.md
@@ -8,7 +8,7 @@ from keras.utils import plot_model
 plot_model(model, to_file='model.png')
 ```
 
-`plot_model`는 네가지 인자를 전달받습니다:
+`plot_model`은 네가지 인자를 전달받습니다:
 
 - `show_shapes`(기본값은 False)는 결과의 형태을 그래프에 나타낼 것인지 조정합니다.
 - `show_layer_names`(기본값은 True)는 층의 이름을 그래프에 나타낼 것인지 조정합니다.
@@ -33,7 +33,7 @@ import matplotlib.pyplot as plt
 
 history = model.fit(x, y, validation_split=0.25, epochs=50, batch_size=16, verbose=1)
 
-# 학습 정확도 값과 검증 정확도 값을 그래프로 나타냅니다. 
+# 학습 정확도와 검증 정확도를 그래프로 나타냅니다. 
 plt.plot(history.history['acc'])
 plt.plot(history.history['val_acc'])
 plt.title('Model accuracy')
@@ -42,7 +42,7 @@ plt.xlabel('Epoch')
 plt.legend(['Train', 'Test'], loc='upper left')
 plt.show()
 
-# 학습 손실 값과 검증 손실 값을 그래프로 나타냅니다.
+# 학습 손실값과 검증 손실값을 그래프로 나타냅니다.
 plt.plot(history.history['loss'])
 plt.plot(history.history['val_loss'])
 plt.title('Model loss')

--- a/sources/visualization.md
+++ b/sources/visualization.md
@@ -10,7 +10,7 @@ plot_model(model, to_file='model.png')
 
 `plot_model`은 네 가지 인자를 전달받습니다:
 
-- `show_shapes`(기본값은 `False`)는 결과의 형태을 그래프에 나타낼지 여부를 설정합니다.
+- `show_shapes`(기본값은 `False`)는 결과의 형태을 그래프에 나타낼 것인지 여부를 설정합니다.
 - `show_layer_names`(기본값은 `True`)는 층의 이름을 그래프에 나타낼 것인지 여부를 설정합니다.
 - `expand_nested`(기본값은 `False`)는 중첩된 모델을 그래프상에서 클러스터로 확장할 것인지 여부를 설정합니다.
 - `dpi`(기본값은 96)는 이미지 dpi를 설정합니다.

--- a/sources/visualization.md
+++ b/sources/visualization.md
@@ -1,6 +1,6 @@
 ## 모델 시각화
 
-케라스는 (`graphviz`를 사용해서) 케라스 모델을 그래프로 그리기 위한 유틸리티 함수를 제공합니다.
+케라스는(`graphviz`를 사용해서) 케라스 모델을 그래프로 그리기 위한 유틸리티 함수를 제공합니다.
 
 아래 예시는 모델의 그래프를 그려주고 그 결과를 파일로 저장합니다:
 ```python
@@ -8,11 +8,11 @@ from keras.utils import plot_model
 plot_model(model, to_file='model.png')
 ```
 
-`plot_model`은 네가지 인자를 전달받습니다:
+`plot_model`은 네 가지 인자를 전달받습니다:
 
-- `show_shapes`(기본값은 False)는 결과의 형태을 그래프에 나타낼 것인지 조정합니다.
-- `show_layer_names`(기본값은 True)는 층의 이름을 그래프에 나타낼 것인지 조정합니다.
-- `expand_nested`(기본값은 False)는 중첩된 모델을 그래프상에서 클러스터로 확장할 것인지 조정합니다.
+- `show_shapes`(기본값은 `False`)는 결과의 형태을 그래프에 나타낼 것인지 조정합니다.
+- `show_layer_names`(기본값은 `True`)는 층의 이름을 그래프에 나타낼 것인지 조정합니다.
+- `expand_nested`(기본값은 `False`)는 중첩된 모델을 그래프상에서 클러스터로 확장할 것인지 조정합니다.
 - `dpi`(기본값은 96)는 이미지 dpi를 조정합니다.
 
 또한 직접 `pydot.Graph`오브젝트를 만들어 사용할 수도 있습니다, 
@@ -26,7 +26,7 @@ SVG(model_to_dot(model).create(prog='dot', format='svg'))
 
 ## 학습 히스토리 시각화
 
-케라스 `Model`의 `fit()` 메소드는 `History` 오브젝트를 반환합니다. `History.history` 속성<sub>Attribute</sub>은 각 에폭마다 계산된 학습 손실 및 평가 지표가 순서대로 기록된 딕셔너리입니다. 검증 데이터를 적용한 경우에는 해당 손실 및 지표도 함께 기록됩니다. 아래는 `matplotlib`을 사용하여 학습 및 검증의 손실과 정확도 그래프를 그리는 예시입니다.
+케라스 `Model`의 `fit()` 메소드는 `History` 오브젝트를 반환합니다. `History.history` 속성<sub>attribute</sub>은 각 에폭마다 계산된 학습 손실 및 평가 지표가 순서대로 기록된 딕셔너리입니다. 검증 데이터를 적용한 경우에는 해당 손실 및 지표도 함께 기록됩니다. 아래는 `matplotlib`을 사용하여 학습 및 검증의 손실과 정확도 그래프를 그리는 예시입니다.
 
 ```python
 import matplotlib.pyplot as plt

--- a/sources/visualization.md
+++ b/sources/visualization.md
@@ -16,7 +16,7 @@ plot_model(model, to_file='model.png')
 - `dpi`(기본값은 96)는 이미지 dpi를 설정합니다.
 
 또한 직접 `pydot.Graph`오브젝트를 만들어 사용할 수도 있습니다. 
-아래는 ipython notebook에 나타낸 예시입니다.
+아래는 IPython Notebook에 나타낸 예시입니다.
 ```python
 from IPython.display import SVG
 from keras.utils import model_to_dot

--- a/sources/visualization.md
+++ b/sources/visualization.md
@@ -2,21 +2,21 @@
 
 케라스는(`graphviz`를 사용해서) 케라스 모델을 그래프로 그리기 위한 유틸리티 함수를 제공합니다.
 
-아래 예시는 모델의 그래프를 그려주고 그 결과를 파일로 저장합니다:
+아래 예시는 모델의 그래프를 그려주고 그 결과를 파일로 저장합니다.
 ```python
 from keras.utils import plot_model
 plot_model(model, to_file='model.png')
 ```
 
-`plot_model`은 네 가지 인자를 전달받습니다:
+`plot_model`은 네 가지 인자를 전달받습니다.
 
 - `show_shapes`(기본값은 `False`)는 결과의 형태을 그래프에 나타낼 것인지 여부를 설정합니다.
 - `show_layer_names`(기본값은 `True`)는 층의 이름을 그래프에 나타낼 것인지 여부를 설정합니다.
 - `expand_nested`(기본값은 `False`)는 중첩된 모델을 그래프상에서 클러스터로 확장할 것인지 여부를 설정합니다.
 - `dpi`(기본값은 96)는 이미지 dpi를 설정합니다.
 
-또한 직접 `pydot.Graph`오브젝트를 만들어 사용할 수도 있습니다, 
-예를들어 ipython notebook에 나타내자면 :
+또한 직접 `pydot.Graph`오브젝트를 만들어 사용할 수도 있습니다. 
+아래는 ipython notebook에 나타낸 예시입니다.
 ```python
 from IPython.display import SVG
 from keras.utils import model_to_dot

--- a/sources/visualization.md
+++ b/sources/visualization.md
@@ -10,10 +10,10 @@ plot_model(model, to_file='model.png')
 
 `plot_model`은 네 가지 인자를 전달받습니다:
 
-- `show_shapes`(기본값은 `False`)는 결과의 형태을 그래프에 나타낼 것인지 조정합니다.
-- `show_layer_names`(기본값은 `True`)는 층의 이름을 그래프에 나타낼 것인지 조정합니다.
-- `expand_nested`(기본값은 `False`)는 중첩된 모델을 그래프상에서 클러스터로 확장할 것인지 조정합니다.
-- `dpi`(기본값은 96)는 이미지 dpi를 조정합니다.
+- `show_shapes`(기본값은 `False`)는 결과의 형태을 그래프에 나타낼지 여부를 설정합니다.
+- `show_layer_names`(기본값은 `True`)는 층의 이름을 그래프에 나타낼 것인지 여부를 설정합니다.
+- `expand_nested`(기본값은 `False`)는 중첩된 모델을 그래프상에서 클러스터로 확장할 것인지 여부를 설정합니다.
+- `dpi`(기본값은 96)는 이미지 dpi를 설정합니다.
 
 또한 직접 `pydot.Graph`오브젝트를 만들어 사용할 수도 있습니다, 
 예를들어 ipython notebook에 나타내자면 :

--- a/sources/visualization.md
+++ b/sources/visualization.md
@@ -26,7 +26,7 @@ SVG(model_to_dot(model).create(prog='dot', format='svg'))
 
 ## 학습 히스토리 시각화
 
-케라스 `Model`의 `fit()` 메소드는 `History` 오브젝트를 반환합니다. `History.history` 속성<sub>Attribute</sub>은 각 에폭마다 계산된 학습 손실 및 평가 지표가 순서대로 기록된 딕셔너리입니다. 검증 데이터를 적용한 경우 해당 손실 및 지표도 함께 기록됩니다. 아래는 `matplotlib`을 사용하여 학습 및 검증의 손실과 정확도 그래프를 그리는 예시입니다.
+케라스 `Model`의 `fit()` 메소드는 `History` 오브젝트를 반환합니다. `History.history` 속성<sub>Attribute</sub>은 각 에폭마다 계산된 학습 손실 및 평가 지표가 순서대로 기록된 딕셔너리입니다. 검증 데이터를 적용한 경우에는 해당 손실 및 지표도 함께 기록됩니다. 아래는 `matplotlib`을 사용하여 학습 및 검증의 손실과 정확도 그래프를 그리는 예시입니다.
 
 ```python
 import matplotlib.pyplot as plt

--- a/sources/visualization.md
+++ b/sources/visualization.md
@@ -1,8 +1,8 @@
 ## 모델 시각화
 
-케라스는(`graphviz`를 사용해서) 케라스 모델을 그래프로 그리기 위한 유틸리티 함수를 제공합니다.  
+케라스는(`graphviz`를 사용해서) 케라스 모델을 그래프로 그리기 위한 유틸리티 함수를 제공합니다.
 
-아래 예시는 모델의 그래프를 그려주고 그 결과를 파일로 저장합니다.  
+아래 예시는 모델의 그래프를 그려주고 그 결과를 파일로 저장합니다.
 ```python
 from keras.utils import plot_model
 plot_model(model, to_file='model.png')
@@ -15,7 +15,7 @@ plot_model(model, to_file='model.png')
 - `expand_nested`(기본값은 `False`)는 중첩된 모델을 그래프상에서 클러스터로 확장할 것인지 여부를 설정합니다.
 - `dpi`(기본값은 96)는 이미지 dpi를 설정합니다.
 
-또한 직접 `pydot.Graph`오브젝트를 만들어 사용할 수도 있습니다.  
+또한 직접 `pydot.Graph`오브젝트를 만들어 사용할 수도 있습니다.
 아래는 IPython Notebook에서 나타낸 예시입니다.
 ```python
 from IPython.display import SVG

--- a/sources/visualization.md
+++ b/sources/visualization.md
@@ -26,14 +26,14 @@ SVG(model_to_dot(model).create(prog='dot', format='svg'))
 
 ## 학습 히스토리 시각화
 
-케라스 `Model`의 `fit()` 메소드는 `History` 오브젝트를 반환합니다. `History.history` 속성은 연속된 에폭에 걸쳐 학습 손실값과 학습 측정항목값을 기록하는 딕셔너리로, 또한 (적용 가능한 경우에는) 검증 손실 값과 검증 측정항목 값도 기록합니다. 아래 간단한 예시에서는 `matplotlib`을 사용하여 학습과 검증에 대한 손실과 정확성 플롯을 만듭니다:
+케라스 `Model`의 `fit()` 메소드는 `History` 오브젝트를 반환합니다. `History.history` 속성<sub>Attribute</sub>은 각 에폭마다 계산된 학습 손실 및 평가 지표가 순서대로 기록된 딕셔너리입니다. 검증 데이터를 적용한 경우 해당 손실 및 지표도 함께 기록됩니다. 아래는 `matplotlib`을 사용하여 학습 및 검증의 손실과 정확도 그래프를 그리는 예시입니다.
 
 ```python
 import matplotlib.pyplot as plt
 
 history = model.fit(x, y, validation_split=0.25, epochs=50, batch_size=16, verbose=1)
 
-# 학습 정확성 값과 검증 정확성 값을 그래프로 나타냅니다. 
+# 학습 정확도 값과 검증 정확도 값을 그래프로 나타냅니다. 
 plt.plot(history.history['acc'])
 plt.plot(history.history['val_acc'])
 plt.title('Model accuracy')


### PR DESCRIPTION
**변경 내용** : '학습 히스토리 시각화' 문단의 단어 및 내용 수정

**내용 수정** 
- 이해하기 쉬운 문장으로 수정(준영님의 sequential.md PR 참고)

**단어 수정**
- 학습 측정 항목값(training metric value) → 학습 지표값(기존 논의내용에 따름)
- 학습 정확성 값(training accuracy values) → 학습 정확도 값(기존 논의내용에 따름)
- 검증 정확성 값(validation accuracy values)→ 검증 정확도 값(기존 논의내용에 따름)
- 플롯→그래프

**그대로 유지**
- 검증 손실 값(validation loss values)
- 학습 손실값(training loss values)